### PR TITLE
Indicate the maven-compiler-plugin to use source level 7 and target 7 (or later)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,14 @@
   <version>1.0-SNAPSHOT</version>
   <name>my-app</name>
   <url>http://maven.apache.org</url>
+  <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+            <source>1.6</source>
+            <target>1.6</target>
+        </configuration>
+    </plugin>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,6 @@
   <version>1.0-SNAPSHOT</version>
   <name>my-app</name>
   <url>http://maven.apache.org</url>
-  <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
-        </configuration>
-    </plugin>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -29,4 +21,8 @@
     <version>6.8.7</version>  
 </dependency>
   </dependencies>
+   <properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
 </project>


### PR DESCRIPTION
With your pom.xml, I received error "Source option 5 is no longer supported. Use 7 or later. "
Since 3.8.0 the default value has changed from 1.5 to 1.6
See https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#target
<plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-compiler-plugin</artifactId> <version>3.8.0</version> </plugin>

We have to indicate the maven-compiler-plugin to use source level 7 and target 7 (or later).